### PR TITLE
Use shared TTS service and cache

### DIFF
--- a/app/deps.py
+++ b/app/deps.py
@@ -1,4 +1,7 @@
+from functools import lru_cache
+
 from fastapi import Depends, Header, HTTPException, status
+
 from .settings import settings
 from .services.route_service import RouteService
 from .services.tts_service import TTSService
@@ -29,7 +32,11 @@ def get_map_service(settings=Depends(get_settings)) -> MapService:
     return MapService(api_key=settings.google_maps_api_key)
 
 
-def get_tts_service(provider: TTSProvider = Depends(get_tts_provider)) -> TTSService:
+@lru_cache()
+def get_tts_service() -> TTSService:
+    """Return a single :class:`TTSService` instance for all requests."""
+
+    provider = get_tts_provider()
     return TTSService(provider)
 
 

--- a/app/utils/caching.py
+++ b/app/utils/caching.py
@@ -1,5 +1,22 @@
+"""Utilities for caching within the application."""
+
 from cachetools import TTLCache
 
 
+_cache: TTLCache | None = None
+
+
 def get_cache(ttl_seconds: int = 1800, maxsize: int = 500) -> TTLCache:
-    return TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+    """Return a shared :class:`~cachetools.TTLCache` instance.
+
+    The first call will create the cache and subsequent calls will return the
+    same instance so that cached data can be reused across the application.
+    Parameters allow configuring the cache on first use.
+    """
+
+    global _cache
+
+    if _cache is None:
+        _cache = TTLCache(maxsize=maxsize, ttl=ttl_seconds)
+
+    return _cache

--- a/tests/test_tts_api.py
+++ b/tests/test_tts_api.py
@@ -1,10 +1,19 @@
+import sys
+from pathlib import Path
+
 import pytest
 from httpx import AsyncClient
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+
+from app.deps import get_tts_service
 from app.main import app
 
 
 @pytest.mark.asyncio
 async def test_tts_synthesize(monkeypatch):
+    get_tts_service.cache_clear()
+
     def fake_tts(self, **kwargs):
         return b"mp3"
 


### PR DESCRIPTION
## Summary
- share a single TTL cache instance across app
- reuse one TTSService via `lru_cache` and ensure tests clear it
- test audio retrieval via `/api/v1/routes/generate` then `/api/v1/tts/by-id`

## Testing
- `pytest -q` *(fails: async def functions are not natively supported and pytest-asyncio couldn't be installed)*

------
https://chatgpt.com/codex/tasks/task_e_689a2e32fe6883279db679be82898abc