### PR TITLE
feat: add structured logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,19 @@ cp .env.example .env
 make dev
 ```
 
+## Logging
+
+Logs use [structlog](https://www.structlog.org/) and can be customized via environment variables:
+
+- `LOG_LEVEL` – set the log verbosity (e.g. `DEBUG`, `INFO`). Default is `INFO`.
+- `LOG_FORMAT` – choose `JSON` for machine readable logs (default) or `PLAIN` for key-value output.
+
+Example:
+
+```bash
+LOG_LEVEL=DEBUG LOG_FORMAT=plain make dev
+```
+
 ## Test
 
 ```bash

--- a/app/logging.py
+++ b/app/logging.py
@@ -1,0 +1,31 @@
+import logging
+import os
+import structlog
+
+
+def setup_logging() -> None:
+    """Configure structlog for the application."""
+    log_level = os.getenv("LOG_LEVEL", "INFO").upper()
+    log_format = os.getenv("LOG_FORMAT", "JSON").upper()
+
+    logging.basicConfig(level=log_level, format="%(message)s")
+
+    processors = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        structlog.processors.TimeStamper(fmt="iso"),
+    ]
+
+    if log_format == "JSON":
+        processors.append(structlog.processors.JSONRenderer())
+    else:
+        processors.append(structlog.processors.KeyValueRenderer(sort_keys=True))
+
+    structlog.configure(
+        processors=processors,
+        context_class=dict,
+        logger_factory=structlog.stdlib.LoggerFactory(),
+        wrapper_class=structlog.stdlib.BoundLogger,
+        cache_logger_on_first_use=True,
+    )
+__all__ = ["setup_logging"]

--- a/app/main.py
+++ b/app/main.py
@@ -5,8 +5,11 @@ from slowapi.util import get_remote_address
 from slowapi.errors import RateLimitExceeded
 from slowapi.middleware import SlowAPIMiddleware
 from fastapi.exceptions import HTTPException
+from .logging import setup_logging
 from .middleware import RequestIDMiddleware, http_exception_handler, general_exception_handler
 from .routers import routes_api, tts_api, health
+
+setup_logging()
 
 limiter = Limiter(key_func=get_remote_address, default_limits=["30/minute"])
 

--- a/app/middleware.py
+++ b/app/middleware.py
@@ -1,5 +1,8 @@
+import time
 import uuid
-from fastapi import Request, HTTPException
+
+import structlog
+from fastapi import HTTPException, Request
 from fastapi.responses import JSONResponse
 from starlette.middleware.base import BaseHTTPMiddleware
 
@@ -8,8 +11,21 @@ class RequestIDMiddleware(BaseHTTPMiddleware):
     async def dispatch(self, request: Request, call_next):
         rid = request.headers.get("X-Request-ID") or str(uuid.uuid4())
         request.state.request_id = rid
+        structlog.contextvars.bind_contextvars(request_id=rid)
+        logger = structlog.get_logger()
+        start = time.time()
+        logger.info("request.start", method=request.method, path=request.url.path)
         response = await call_next(request)
+        duration = int((time.time() - start) * 1000)
         response.headers["X-Request-ID"] = rid
+        logger.info(
+            "request.end",
+            method=request.method,
+            path=request.url.path,
+            status_code=response.status_code,
+            duration_ms=duration,
+        )
+        structlog.contextvars.clear_contextvars()
         return response
 
 

--- a/app/routers/health.py
+++ b/app/routers/health.py
@@ -1,13 +1,17 @@
 from fastapi import APIRouter
+import structlog
 
 router = APIRouter(tags=["health"])
+logger = structlog.get_logger()
 
 
 @router.get("/healthz")
 async def healthz():
+    logger.info("healthz")
     return {"status": "ok"}
 
 
 @router.get("/readyz")
 async def readyz():
+    logger.info("readyz")
     return {"status": "ready"}

--- a/app/routers/routes_api.py
+++ b/app/routers/routes_api.py
@@ -1,9 +1,11 @@
 from fastapi import APIRouter, Depends, HTTPException, status
+import structlog
 from ..schemas import RouteGenerateRequest, RouteResponse
 from ..deps import get_route_service, api_key_auth
 from ..services.route_service import RouteService
 
 router = APIRouter(prefix="/api/v1/routes", tags=["routes"])
+logger = structlog.get_logger()
 
 
 @router.post("/generate", response_model=RouteResponse)
@@ -12,6 +14,7 @@ async def generate_route(
     service: RouteService = Depends(get_route_service),
     _: str = Depends(api_key_auth),
 ):
+    logger.info("route.generate.start", city=req.city)
     try:
         route = await service.generate_route(
             city=req.city,
@@ -22,6 +25,8 @@ async def generate_route(
             language=req.language or "en",
             need_audio=req.need_audio,
         )
+        logger.info("route.generate.success", route_id=route["route_id"], city=req.city)
         return RouteResponse(**route)
     except Exception as e:
+        logger.exception("route.generate.error", city=req.city)
         raise HTTPException(status_code=status.HTTP_424_FAILED_DEPENDENCY, detail=str(e))

--- a/app/routers/tts_api.py
+++ b/app/routers/tts_api.py
@@ -1,21 +1,27 @@
 from fastapi import APIRouter, Depends, HTTPException, Query
 from fastapi.responses import StreamingResponse
+import structlog
 from ..deps import get_tts_service, api_key_auth
 from ..schemas import TTSSynthesizeRequest
 from ..services.tts_service import TTSService
 
 router = APIRouter(prefix="/api/v1/tts", tags=["tts"])
+logger = structlog.get_logger()
 
 
 @router.get("/by-id")
 async def tts_by_id(rid: str = Query(...), poi: str = Query(...), service: TTSService = Depends(get_tts_service)):
+    logger.info("tts.by_id", route_id=rid, poi_id=poi)
     audio = service.get_cached(rid, poi)
     if not audio:
+        logger.warning("tts.by_id.miss", route_id=rid, poi_id=poi)
         raise HTTPException(status_code=404, detail="audio not found")
+    logger.info("tts.by_id.hit", route_id=rid, poi_id=poi)
     return StreamingResponse(iter([audio]), media_type="audio/mpeg")
 
 
 @router.post("/synthesize")
 async def synthesize(req: TTSSynthesizeRequest, service: TTSService = Depends(get_tts_service), _: str = Depends(api_key_auth)):
+    logger.info("tts.synthesize", language=req.language_code)
     audio = service.synthesize(text=req.text, language_code=req.language_code, voice_name=req.voice_name)
     return StreamingResponse(iter([audio]), media_type="audio/mpeg")

--- a/app/services/tts_service.py
+++ b/app/services/tts_service.py
@@ -1,24 +1,42 @@
 from ..integrations.tts_provider import TTSProvider
 from ..utils.caching import get_cache
 from ..settings import settings
+import structlog
 
 
 class TTSService:
     def __init__(self, provider: TTSProvider):
         self.provider = provider
         self.cache = get_cache()
+        self.logger = structlog.get_logger(__name__)
 
     def cache_key(self, route_id: str, poi_id: str) -> str:
         return f"{route_id}:{poi_id}"
 
     def get_cached(self, route_id: str, poi_id: str) -> bytes | None:
-        return self.cache.get(self.cache_key(route_id, poi_id))
+        audio = self.cache.get(self.cache_key(route_id, poi_id))
+        if audio:
+            self.logger.info("tts.cache.hit", route_id=route_id, poi_id=poi_id)
+        else:
+            self.logger.info("tts.cache.miss", route_id=route_id, poi_id=poi_id)
+        return audio
 
     def set_cached(self, route_id: str, poi_id: str, data: bytes) -> None:
+        self.logger.info("tts.cache.set", route_id=route_id, poi_id=poi_id)
         self.cache[self.cache_key(route_id, poi_id)] = data
 
     def synthesize_story(self, *, text: str, language: str) -> bytes:
-        return self.provider.synthesize(text=text, language_code=language or settings.default_language, voice_name=settings.default_voice)
+        self.logger.info("tts.synthesize_story", language=language)
+        return self.provider.synthesize(
+            text=text,
+            language_code=language or settings.default_language,
+            voice_name=settings.default_voice,
+        )
 
     def synthesize(self, *, text: str, language_code: str, voice_name: str | None = None) -> bytes:
-        return self.provider.synthesize(text=text, language_code=language_code or settings.default_language, voice_name=voice_name or settings.default_voice)
+        self.logger.info("tts.synthesize", language_code=language_code)
+        return self.provider.synthesize(
+            text=text,
+            language_code=language_code or settings.default_language,
+            voice_name=voice_name or settings.default_voice,
+        )


### PR DESCRIPTION
## Summary
- configure structlog with JSON/PLAIN formats and env-based level
- log request lifecycle and bind request IDs
- instrument routers and services with structured logging
- document log configuration via environment variables

## Testing
- `make test` *(fails: Makefile missing tabs)*
- `pytest` *(fails: async tests require pytest-asyncio; network restrictions blocked installation)*

------
https://chatgpt.com/codex/tasks/task_e_689a34abd2108327aa7b4750dc0e317d